### PR TITLE
Update README: Include information on required upload-artifact version

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ with the summary of the code coverage changes.
   In a repository which receives changes only infrequently, this might lead to issues when trying to compare
   the code coverage of a pull request with the code coverage of the main branch (see fgrosse/go-coverage-report#5).  
 - Packages with a name that differs from their directory on disk are not supported yet.
-- Requires actions/upload-artifact@v4 to [avoid issues when subsequently attempting to download run artifacts via the Github CLI]([https://github.com/cli/cli/issues/5625](https://github.com/cli/cli/issues/5625#issuecomment-1857787634)).
+- Requires actions/upload-artifact@v4 to [avoid issues when subsequently attempting to download run artifacts via the Github CLI](https://github.com/cli/cli/issues/5625#issuecomment-1857787634).
 
 ## Built With
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ with the summary of the code coverage changes.
   In a repository which receives changes only infrequently, this might lead to issues when trying to compare
   the code coverage of a pull request with the code coverage of the main branch (see fgrosse/go-coverage-report#5).  
 - Packages with a name that differs from their directory on disk are not supported yet.
+- Requires actions/upload-artifact@v4 to [avoid issues when subsequently attempting to download run artifacts via the Github CLI]([https://github.com/cli/cli/issues/5625](https://github.com/cli/cli/issues/5625#issuecomment-1857787634)).
 
 ## Built With
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ with the summary of the code coverage changes.
   In a repository which receives changes only infrequently, this might lead to issues when trying to compare
   the code coverage of a pull request with the code coverage of the main branch (see fgrosse/go-coverage-report#5).  
 - Packages with a name that differs from their directory on disk are not supported yet.
-- Requires actions/upload-artifact@v4 to [avoid issues when subsequently attempting to download run artifacts via the Github CLI](https://github.com/cli/cli/issues/5625#issuecomment-1857787634).
+- Requires `actions/upload-artifact` >= **v4** (see this [issue][upload-artifacts-issues]).
 
 ## Built With
 
@@ -187,3 +187,4 @@ This project is licensed under the BSD-3-Clause License - see the [LICENSE](LICE
 [releases]: https://github.com/fgrosse/go-coverage-report/release
 [contributors]: https://github.com/fgrosse/go-coverage-report/contributors
 [built-with]: go.mod
+[upload-artifacts-issues]: https://github.com/cli/cli/issues/5625#issuecomment-1857787634


### PR DESCRIPTION
Add information noting that you must use upload-artifact@v4 for the subsequent `gh run download` calls to work.
Utilizing my repo's current upload which used v3 was unsuccessful. 