### PR TITLE
Use github.workflow_ref to fix issues when workflow files are renamed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-_Nothing so far_
+- Fix issue when the workflow file is renamed (fgrosse/go-coverage-report#41)
 
 ## [v1.1.0] - 2024-07-25
 - Document permissions needed to use this action (fgrosse/go-coverage-report#32)

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
       env:
         GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
-        GITHUB_WORKFLOW: ${{ github.workflow }}
+        GITHUB_WORKFLOW_REF: ${{ github.workflow_ref }}
         GITHUB_BASE_REF: ${{ github.base_ref }}
         CHANGED_FILES_PATH: .github/outputs/all_modified_files.json
         COVERAGE_ARTIFACT_NAME: ${{ inputs.coverage-artifact-name }}

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -25,6 +25,7 @@ this in the workflow file:
 
 You can use the following environment variables to configure the script:
 - GITHUB_WORKFLOW: The name of the Workflow (default: CI)
+- GITHUB_WORKFLOW_REF: The ref path to the workflow to use instead of GITHUB_WORKFLOW (optional)
 - GITHUB_BASE_REF: The base branch to compare the coverage results against (default: main)
 - COVERAGE_ARTIFACT_NAME: The name of the artifact containing the code coverage results (default: code-coverage)
 - COVERAGE_FILE_NAME: The name of the file containing the code coverage results (default: coverage.txt)
@@ -72,6 +73,11 @@ fi
 if [[ -z ${GITHUB_OUTPUT+x} ]]; then
     echo "Missing GITHUB_OUTPUT environment variable"
     exit 1
+fi
+
+# If GITHUB_WORKFLOW_REF is defined, extract the workflow file path from it and use it instead of GITHUB_WORKFLOW
+if [[ -n ${GITHUB_WORKFLOW_REF+x} ]]; then
+    GITHUB_WORKFLOW=$(basename "${GITHUB_WORKFLOW_REF%%@*}")
 fi
 
 export GH_REPO="$GITHUB_REPOSITORY"


### PR DESCRIPTION
When the workflow file in a repository is renamed, the GitHub CLI will choke on listing workflow runs:

```
  ++ gh run list --status=success --branch=main --workflow=CI --event=push --json=databaseId --limit=1 -q '.[] | .databaseId'
  could not resolve to a unique workflow; found: ci.yaml pr-ci.yaml
```

This PR changes the logic to determine the `--workflow` argument. Instead of using the human readable workflow name, we can use the filename of the workflow to make `gh` happy.
