### PR TITLE
Fix permissions for commenting on PRs from forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ This action provides the following outputs:
 - Packages with a name that differs from their directory on disk are not supported yet.
 - Requires `actions/upload-artifact` >= **v4** (see this [issue][upload-artifacts-issues]).
 
+### Workaround for Forks
+
+If you need to support forks, you can use the `pull_request_target` event as a workaround. However, be aware that this comes with a significant security risk. The `pull_request_target` event runs in the context of the base repository, which means it has access to secrets and write permissions. This can be exploited by malicious code in the pull request. Therefore, you should avoid checking out the code from the pull request and be very cautious about what actions you perform.
+
+For more information, see the [GitHub documentation on `pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target).
+
 ## Built With
 
 * [tj-actions/changed-files](https://github.com/tj-actions/changed-files) - A GitHub Action to get the list of changed files in pull requests


### PR DESCRIPTION
Fixes #15

Add a note about using `pull_request_target` as a workaround for forks in the `README.md`.

* Add a section titled "Workaround for Forks" explaining the use of `pull_request_target`.
* Include a security warning about the risks associated with using `pull_request_target`.
* Provide a link to the GitHub documentation on `pull_request_target`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fgrosse/go-coverage-report/issues/15?shareId=b105b4c2-826e-4a05-a209-f83336af27d4).