### PR TITLE
Set version to v42.1.0 for changed-files action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ runs:
 
     - name: Determine changed files
       id: changed-files
-      uses: tj-actions/changed-files@aa08304bd477b800d468db44fe10f6c61f7f7b11 # v42.1.0
+      uses: tj-actions/changed-files@v42.1.0
       with:
         write_output_files: true
         json: true


### PR DESCRIPTION
Use release tag to pin the `tj-actions/changed-files` dependency action due to issues faced when attempting to allow usage of this action within a GitHub org.