### PR TITLE
Add a excluded-filter parameter to allow excluding some files from the report

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ inputs:
     description: Trim a prefix in the "Impacted Packages" column of the markdown report.
     required: false
 
+  exclude-filter:
+    description: Exclude files matching the given regular expression from the report.
+    required: false
+    
   github-baseline-workflow-ref:
     description: |
       The ref of the GitHub actions Workflow that produces the baseline coverage.

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: Trim a prefix in the "Impacted Packages" column of the markdown report.
     required: false
 
+  exclude-filter:
+    description: Exclude files matching the given regular expression from the report.
+    required: false
+
   github-baseline-workflow-ref:
     description: |
       The ref of the GitHub actions Workflow that produces the baseline coverage.
@@ -98,3 +102,4 @@ runs:
         ROOT_PACKAGE: ${{ inputs.root-package }}
         SKIP_COMMENT: ${{ inputs.skip-comment }}
         TRIM_PACKAGE: ${{ inputs.trim }}
+        EXCLUDE_FILTER: ${{ inputs.exclude-filter }}

--- a/cmd/go-coverage-report/coverage.go
+++ b/cmd/go-coverage-report/coverage.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"path"
+	"regexp"
 
 	"github.com/pkg/errors"
 )
@@ -13,8 +14,8 @@ type Coverage struct {
 	MissedStmt  int64
 }
 
-func ParseCoverage(filename string) (*Coverage, error) {
-	pp, err := ParseProfiles(filename)
+func ParseCoverage(filename string, excludeFilter *regexp.Regexp) (*Coverage, error) {
+	pp, err := ParseProfiles(filename, excludeFilter)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse profiles")
 	}

--- a/cmd/go-coverage-report/coverage_test.go
+++ b/cmd/go-coverage-report/coverage_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,7 +9,7 @@ import (
 )
 
 func TestParse(t *testing.T) {
-	cov, err := ParseCoverage("testdata/01-new-coverage.txt")
+	cov, err := ParseCoverage("testdata/01-new-coverage.txt", nil)
 	require.NoError(t, err)
 
 	assert.EqualValues(t, 102, cov.TotalStmt)
@@ -18,7 +19,7 @@ func TestParse(t *testing.T) {
 }
 
 func TestCoverage_ByPackage(t *testing.T) {
-	cov, err := ParseCoverage("testdata/01-new-coverage.txt")
+	cov, err := ParseCoverage("testdata/01-new-coverage.txt", nil)
 	require.NoError(t, err)
 
 	pkgs := cov.ByPackage()
@@ -28,5 +29,21 @@ func TestCoverage_ByPackage(t *testing.T) {
 	assert.NotNil(t, pkgCov)
 	assert.EqualValues(t, 102, pkgCov.TotalStmt)
 	assert.EqualValues(t, 92, pkgCov.CoveredStmt)
+	assert.EqualValues(t, 10, pkgCov.MissedStmt)
+}
+
+func TestCoverage_ByPackageFiltered(t *testing.T) {
+
+	regex := regexp.MustCompile(".*max_.*.go")
+	cov, err := ParseCoverage("testdata/01-new-coverage.txt", regex)
+	require.NoError(t, err)
+
+	pkgs := cov.ByPackage()
+	assert.Len(t, pkgs, 1)
+
+	pkgCov := pkgs["github.com/fgrosse/prioqueue"]
+	assert.NotNil(t, pkgCov)
+	assert.EqualValues(t, 52, pkgCov.TotalStmt)
+	assert.EqualValues(t, 42, pkgCov.CoveredStmt)
 	assert.EqualValues(t, 10, pkgCov.MissedStmt)
 }

--- a/cmd/go-coverage-report/report_test.go
+++ b/cmd/go-coverage-report/report_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func TestReport_Markdown(t *testing.T) {
-	oldCov, err := ParseCoverage("testdata/01-old-coverage.txt")
+	oldCov, err := ParseCoverage("testdata/01-old-coverage.txt", nil)
 	require.NoError(t, err)
 
-	newCov, err := ParseCoverage("testdata/01-new-coverage.txt")
+	newCov, err := ParseCoverage("testdata/01-new-coverage.txt", nil)
 	require.NoError(t, err)
 
 	changedFiles, err := ParseChangedFiles("testdata/01-changed-files.json", "github.com/fgrosse/prioqueue")
@@ -47,10 +47,10 @@ _Please note that the "Total", "Covered", and "Missed" counts above refer to ***
 }
 
 func TestReport_Markdown_OnlyChangedUnitTests(t *testing.T) {
-	oldCov, err := ParseCoverage("testdata/02-old-coverage.txt")
+	oldCov, err := ParseCoverage("testdata/02-old-coverage.txt", nil)
 	require.NoError(t, err)
 
-	newCov, err := ParseCoverage("testdata/02-new-coverage.txt")
+	newCov, err := ParseCoverage("testdata/02-new-coverage.txt", nil)
 	require.NoError(t, err)
 
 	changedFiles, err := ParseChangedFiles("testdata/02-changed-files.json", "github.com/fgrosse/prioqueue")


### PR DESCRIPTION
This allow adding a regex filter to exclude some files from the report.

Fix: #56
