### PR TITLE
Fix goreleaser deprecations and use CHANGELOG.md for release notes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,18 +14,14 @@ builds:
     main: ./cmd/go-coverage-report
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: '{{ .ProjectName }}-v{{ .Version }}-{{ title .Os | tolower }}-{{- .Arch }}'
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 checksum:
   name_template: 'checksums.txt'
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  disable: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -52,14 +52,18 @@ git push origin vX.Y.Z
 
 ### 5. Run goreleaser
 
+Extract the release notes for the current version from `CHANGELOG.md` and pass them to goreleaser:
+
 ```bash
-goreleaser release --clean
+VERSION=vX.Y.Z
+awk "/^## \[$VERSION\]/{found=1; next} /^## \[v/{if(found) exit} found" CHANGELOG.md > /tmp/release-notes.md
+goreleaser release --clean --release-notes=/tmp/release-notes.md
 ```
 
 This will:
 - Build binaries for Linux, macOS, and Windows
 - Create tarballs and a `checksums.txt`
-- Publish a GitHub Release with the artifacts and changelog
+- Publish a GitHub Release using the curated `CHANGELOG.md` notes
 
 ## Checklist
 
@@ -68,4 +72,4 @@ This will:
 - [ ] `README.md` version references bumped
 - [ ] Changes committed and pushed to `main`
 - [ ] Signed tag created and pushed (pointing to the version-bump commit)
-- [ ] `goreleaser release --clean` run successfully
+- [ ] `goreleaser release --clean --release-notes=/tmp/release-notes.md` run successfully


### PR DESCRIPTION
## Summary

- Fix deprecated `archives.format` → `formats` (now a list) for both tar.gz and zip overrides
- Disable goreleaser's auto-generated commit-based changelog
- Add `--release-notes` approach to use curated `CHANGELOG.md` content for GitHub Release notes
- Update `RELEASING.md` with the new goreleaser invocation

## Test plan

- [x] Run `goreleaser release --snapshot --clean` to verify the config builds correctly
- [x] Verify the `awk` command in `RELEASING.md` correctly extracts a version section from `CHANGELOG.md`